### PR TITLE
プルリクエストのイベントタイプの変更

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,6 +14,8 @@ on:
     types:
       - opened
       - reopened
+      - ready_for_review
+      - synchronize
 
 jobs:
   call_workflow:

--- a/.github/README.md
+++ b/.github/README.md
@@ -13,9 +13,7 @@ on:
   pull_request_target:
     types:
       - opened
-      - reopened
       - ready_for_review
-      - synchronize
 
 jobs:
   call_workflow:


### PR DESCRIPTION
## 概要
ワークフローのイベントトリガーである、`pull_request_target`のタイプに`ready_for_review`を追加し、`reopened`を削除しました。私自身としては、変更後のタイプの方が過不足なくて良いと思います。

## 詳細
`ready_for_review`は、プルリクエストのドラフトがレビューできる状態になったときにトリガーされるイベントです。

`reopened`は、プルリクエストが再オープンされたらトリガーされるイベントですが、プルリクエストがクローズされている間にマージ元のブランチに変更があってそれを基に再オープンするかなと考えたときに、そんなことないなと思って削除しました。

## 懸念点
`synchronize`イベントも含めようかと思いましたが（含めるとマージ元のブランチに変更があればレビューが依頼される）、変更がある度にレビュー依頼が飛んできてうざいかなと思って入れなかったのですが、どうでしょうか？

利点：変更があればレビュー依頼が飛んでくるのでプルリクエスト提出後の変更を見逃さない
難点：変更がある度にレビュー依頼が飛んでくるので鬱陶しく感じる可能性がある。

と書きましたが、実際レビューしたら、該当のプルリクエストからの通知が有効なはずなので見逃す可能性は小さいかも？