### PR TITLE
コアワークフローで権限を明記

### DIFF
--- a/.github/workflows/request_review_core.yml
+++ b/.github/workflows/request_review_core.yml
@@ -13,6 +13,8 @@ jobs:
     name: Request a review for the pull request to ${{ inputs.reviewer }}
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v3.1.4


### PR DESCRIPTION
## 概要
`request_review_core.yml`内で定義されているジョブにおいて、プルリクエストへの書き込み権限を明記しました。

ワークフローの呼び出し元で既にプルリクエストの書き込み権限は付与されているので、ここで明記しないからといってワークフローがエラーになるとは思いませんが、わかりやすく明記しておきました。